### PR TITLE
Fix build.sh

### DIFF
--- a/Libs/build.sh
+++ b/Libs/build.sh
@@ -18,7 +18,7 @@ cp -rf input/Release-iphonesimulator/$framework.framework output/$framework.fram
 lipo -create input/Release-iphonesimulator/$framework.framework/$framework input/Release-iphoneos/$framework.framework/$framework -output output/$framework.framework/$framework
 
 ## Copy result to output
-cp -rf input/Release-iphonesimulator/$framework.framework/Modules/$framework.swiftmodule output/$framework.framework/Modules/$framework.swiftmodule
+cp -rf input/Release-iphoneos/$framework.framework/Modules/$framework.swiftmodule output/$framework.framework/Modules/$framework.swiftmodule
 
 ### -----------------------------------------
 ### GENERATE API DEFINITION


### PR DESCRIPTION
Fix build script to copy iphone swiftmodule instead of simulator swiftmodule (else the binding does not work for devices)